### PR TITLE
callBlacklistRule: Return all positions and add ability to check CreateFunc, ExistsFunc, ReadFunc, and UpdateFunc

### DIFF
--- a/rules/call_blacklist.go
+++ b/rules/call_blacklist.go
@@ -73,7 +73,7 @@ func (rule *callBlacklistRule) CheckResource(readOnly bool, r *provparse.Resourc
 		}
 	}
 
-	if !readOnly && r.ExistsFunc != nil {
+	if r.ExistsFunc != nil {
 		if calls := rule.functionCalls(r.ExistsFunc, rule.Exists); len(calls) > 0 {
 			// it makes some of the calls, need to append issues
 			for call, positions := range calls {
@@ -92,7 +92,7 @@ func (rule *callBlacklistRule) CheckResource(readOnly bool, r *provparse.Resourc
 		}
 	}
 
-	if !readOnly && r.ReadFunc != nil {
+	if r.ReadFunc != nil {
 		if calls := rule.functionCalls(r.ReadFunc, rule.Read); len(calls) > 0 {
 			// it makes some of the calls, need to append issues
 			for call, positions := range calls {


### PR DESCRIPTION
Previously, it was only returning the final `token.Pos` for each `CreateFunc`/`DeleteFunc`/`ReadFunc`/`UpdateFunc` 😄  

```
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:725:25: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
```

Now it correctly returns everything:

```
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:269:23: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:329:23: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:343:24: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:694:23: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:710:23: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint999] aws/resource_aws_lb.go:725:25: Create, Read, Update, and Delete functions should call fmt.Errorf() instead of github.com/hashicorp/errwrap.Wrapf
```