### PR TITLE
New Rule 029: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ tfprovlint lint github.com/terraform-providers/terraform-provider-aws
 | tfprovlint026 | Do not use reserved field names | Resource |  |
 | tfprovlint027 | SDK version is less than 0.11 |  | not yet implemented |
 | tfprovlint028 | Do not log resource data values |  | not yet implemented |
+| tfprovlint029 | Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf |  |  |
 
 <!-- TODO: add rules from the importer's InternalValidate -->
 

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -14,6 +14,7 @@ var resourceRules = map[string]ruleFactoryFunc{
 	// "tfprovlint004": err check sets on complex types
 	"tfprovlint005": rules.NewDoNotDereferencePointersInSetRule,
 	"tfprovlint026": rules.NewNoReservedNamesRule,
+	"tfprovlint029": rules.NewNoErrwrapWrapfInResourceFuncRule,
 }
 
 func loadRules(includes, excludes []string) map[string]ruleFactoryFunc {

--- a/rules/call_blacklist.go
+++ b/rules/call_blacklist.go
@@ -26,11 +26,22 @@ var _ lint.ResourceRule = &callBlacklistRule{}
 func (rule *callBlacklistRule) CheckResource(readOnly bool, r *provparse.Resource) ([]lint.Issue, error) {
 	var issues []lint.Issue
 
+	// Prevent duplicate issues
+	existingCallPos := map[string]map[token.Pos]bool{}
+
 	if !readOnly && r.CreateFunc != nil {
 		if calls := rule.functionCalls(r.CreateFunc, rule.Create); len(calls) > 0 {
 			// it makes some of the calls, need to append issues
 			for call, positions := range calls {
 				for _, pos := range positions {
+					if _, ok := existingCallPos[call]; !ok {
+						existingCallPos[call] = map[token.Pos]bool{pos: true}
+						continue
+					}
+					if existingCallPos[call][pos] {
+						continue
+					}
+					existingCallPos[call][pos] = true
 					issues = append(issues, lint.NewIssuef(pos, rule.IssueMessageFormat, call))
 				}
 			}
@@ -47,6 +58,14 @@ func (rule *callBlacklistRule) CheckResource(readOnly bool, r *provparse.Resourc
 			// it makes some of the calls, need to append issues
 			for call, positions := range calls {
 				for _, pos := range positions {
+					if _, ok := existingCallPos[call]; !ok {
+						existingCallPos[call] = map[token.Pos]bool{pos: true}
+						continue
+					}
+					if existingCallPos[call][pos] {
+						continue
+					}
+					existingCallPos[call][pos] = true
 					issues = append(issues, lint.NewIssuef(pos, rule.IssueMessageFormat, call))
 				}
 			}
@@ -58,6 +77,14 @@ func (rule *callBlacklistRule) CheckResource(readOnly bool, r *provparse.Resourc
 			// it makes some of the calls, need to append issues
 			for call, positions := range calls {
 				for _, pos := range positions {
+					if _, ok := existingCallPos[call]; !ok {
+						existingCallPos[call] = map[token.Pos]bool{pos: true}
+						continue
+					}
+					if existingCallPos[call][pos] {
+						continue
+					}
+					existingCallPos[call][pos] = true
 					issues = append(issues, lint.NewIssuef(pos, rule.IssueMessageFormat, call))
 				}
 			}
@@ -69,6 +96,14 @@ func (rule *callBlacklistRule) CheckResource(readOnly bool, r *provparse.Resourc
 			// it makes some of the calls, need to append issues
 			for call, positions := range calls {
 				for _, pos := range positions {
+					if _, ok := existingCallPos[call]; !ok {
+						existingCallPos[call] = map[token.Pos]bool{pos: true}
+						continue
+					}
+					if existingCallPos[call][pos] {
+						continue
+					}
+					existingCallPos[call][pos] = true
 					issues = append(issues, lint.NewIssuef(pos, rule.IssueMessageFormat, call))
 				}
 			}

--- a/rules/constants.go
+++ b/rules/constants.go
@@ -2,6 +2,8 @@ package rules
 
 // well known SDK funcs
 const (
+	funcErrwrapWrapf = "github.com/hashicorp/errwrap.Wrapf"
+
 	funcResourceDataSetId = "(*github.com/hashicorp/terraform/helper/schema.ResourceData).SetId"
 	funcResourceDataSet   = "(*github.com/hashicorp/terraform/helper/schema.ResourceData).Set"
 

--- a/rules/rule_029.go
+++ b/rules/rule_029.go
@@ -1,0 +1,17 @@
+package rules
+
+import "github.com/paultyng/tfprovlint/lint"
+
+func NewNoErrwrapWrapfInResourceFuncRule() lint.ResourceRule {
+	funcBlacklist := map[string]bool{}
+	funcBlacklist[funcErrwrapWrapf] = true
+
+	return &callBlacklistRule{
+		IssueMessageFormat: "Resource functions should call fmt.Errorf instead of %s",
+		Create:             funcBlacklist,
+		Delete:             funcBlacklist,
+		Exists:             funcBlacklist,
+		Read:               funcBlacklist,
+		Update:             funcBlacklist,
+	}
+}


### PR DESCRIPTION
Requires #13
Closes #10 

e.g.

```
[aws_lb] [tfprovlint029] aws/resource_aws_lb.go:329:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint029] aws/resource_aws_lb.go:343:24: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint029] aws/resource_aws_lb.go:694:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint029] aws/resource_aws_lb.go:710:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb] [tfprovlint029] aws/resource_aws_lb.go:725:25: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_listener] [tfprovlint029] aws/resource_aws_lb_listener.go:163:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_listener] [tfprovlint029] aws/resource_aws_lb_listener.go:241:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_listener] [tfprovlint029] aws/resource_aws_lb_listener.go:254:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_listener_rule] [tfprovlint029] aws/resource_aws_lb_listener_rule.go:283:24: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_listener_rule] [tfprovlint029] aws/resource_aws_lb_listener_rule.go:303:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:269:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:283:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:322:25: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:374:24: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:388:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:480:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group] [tfprovlint029] aws/resource_aws_lb_target_group.go:506:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group_attachment] [tfprovlint029] aws/resource_aws_lb_target_group_attachment.go:104:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
[aws_lb_target_group_attachment] [tfprovlint029] aws/resource_aws_lb_target_group_attachment.go:142:23: Resource functions should call fmt.Errorf instead of github.com/hashicorp/errwrap.Wrapf
```