### PR TITLE
Fix crash when provider has no datasources

### DIFF
--- a/provparse/provider.go
+++ b/provparse/provider.go
@@ -1,7 +1,6 @@
 package provparse
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 	"go/types"
@@ -113,7 +112,7 @@ func (p *provParser) extractResourceFuncNames(cl *ast.CompositeLit) (map[string]
 	// }
 
 	if cl == nil {
-		return nil, errors.New("Unable to extract reource function names")
+		return nil, nil
 	}
 
 	res := map[string]string{}

--- a/provparse/provider.go
+++ b/provparse/provider.go
@@ -1,6 +1,7 @@
 package provparse
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/types"
@@ -110,6 +111,10 @@ func (p *provParser) extractResourceFuncNames(cl *ast.CompositeLit) (map[string]
 	// if _, ok := cl.Type.(*ast.MapType); !ok {
 	// 	return error?
 	// }
+
+	if cl == nil {
+		return nil, errors.New("Unable to extract reource function names")
+	}
 
 	res := map[string]string{}
 


### PR DESCRIPTION
:wave: Ran into an issue attempting to lint a [provider](github.com/Mongey/terraform-provider-kafka). 

Judging by the commented out code above this change, you may have a different approach in mind -- but this stops the crash I'm hitting 😄
```
./tfprovlint lint github.com/Mongey/terraform-provider-kafka
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x123db05]

goroutine 1 [running]:
github.com/paultyng/tfprovlint/provparse.(*provParser).extractResourceFuncNames(0xc452659470, 0x0, 0xc45265efe0, 0x700000000000002, 0xffffffffffffffff)
````